### PR TITLE
Fix a bug with custom attribute name clashes (#590)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Make skorch compatible with sklearn 0.22
+- Fixed a bug that could occur when a new "settable" (via `set_params`) attribute was added to `NeuralNet` whose name starts the same as an existing attribute's name
 
 ## [0.7.0] - 2019-11-29
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1345,7 +1345,10 @@ class NeuralNet:
         for key in kwargs:
             if key.endswith('_'):
                 continue
-            for prefix in self.prefixes_:
+
+            # see https://github.com/skorch-dev/skorch/pull/590 for
+            # why this must be sorted
+            for prefix in sorted(self.prefixes_, key=lambda s: (-len(s), s)):
                 if key.startswith(prefix):
                     if not key.startswith(prefix + '__'):
                         missing_dunder_kwargs.append((prefix, key))


### PR DESCRIPTION
Fix a bug with custom attribute name clashes

When a user adds a new "settable" attribute (i.e. that works with
set_params) whose names starts the same as an existing attribute (say
"optimizer_2"), and adds a corresponding argument (say
"optimizer_2__lr"), skorch will erroneously complain about this
argument because it thinks it belongs to the other
attribute ("optimizer" in this example). The added unit test should
illustrate this behavior.